### PR TITLE
Update build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -8,3 +8,5 @@ if (-not ($PSVersionTable.PSEdition -eq "Core")) {
 }
 
 & $buildScript -j12 NDK_PROJECT_PATH=$PSScriptRoot APP_BUILD_SCRIPT=$PSScriptRoot/Android.mk NDK_APPLICATION_MK=$PSScriptRoot/Application.mk V=1
+
+exit $LastExitCode


### PR DESCRIPTION
Should make the action actually fail if the build fails, instead of failing to find the lib files